### PR TITLE
Dont delete generated ActionID from responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Default values:
     emitEventsByTypes: true,
     eventTypeToLowerCase: false,
     emitResponsesById: true,
+    dontDeleteSpecActionId: false,
     addTime: false,
     eventFilter: null  // filter disabled
 }
@@ -233,6 +234,7 @@ Default values:
 * `emitEventsByTypes` - when is `true`, client will emit events by names. See [example 5](#example-5);
 * `eventTypeToLowerCase` - when is `true`, client will emit events by names in lower case. Uses with `emitEventsByTypes`;
 * `emitResponsesById` - when is `true` and data package of action has ActionID field, client will emit responses by `resp_ActionID`. See [example 5](#example-5);
+* `dontDeleteSpecActionId` - when is `true`, client will not hide generated ActionID field in responses;
 * `addTime` - when is `true`, client will be add into events and responses field `$time` with value equal to ms-timestamp;
 * `eventFilter` - object, array or Set with names of events, which will be ignored by client. 
 

--- a/lib/AmiClient.js
+++ b/lib/AmiClient.js
@@ -36,6 +36,7 @@ class AmiClient extends EventEmitter{
                 emitEventsByTypes: true,
                 eventTypeToLowerCase: false,
                 emitResponsesById: true,
+                dontDeleteSpecActionId: false,
                 addTime: false,
                 eventFilter: null
             }, options || {}),
@@ -110,7 +111,7 @@ class AmiClient extends EventEmitter{
                             }
                             this._prEmitter.emit(`resp_${response.ActionID}`, response);
 
-                            if(response.ActionID.startsWith(this._specPrefix)){
+                            if(!this._options.dontDeleteSpecActionId && response.ActionID.startsWith(this._specPrefix)){
                                 delete response.ActionID;
                             }
                         }
@@ -352,7 +353,8 @@ class AmiClient extends EventEmitter{
      */
     get lastResponse(){
         let response = this._connection ? this._connection.lastResponse : null;
-        if(response && response.ActionID && response.ActionID.startsWith(this._specPrefix)){
+        if(response && response.ActionID && !this._options.dontDeleteSpecActionId 
+                && response.ActionID.startsWith(this._specPrefix)){
             delete response.ActionID;
         }
         return response

--- a/test/amiClientTest.js
+++ b/test/amiClientTest.js
@@ -445,6 +445,7 @@ describe('Ami Client internal functionality', function(){
                 emitEventsByTypes: true,
                 eventTypeToLowerCase: false,
                 emitResponsesById: true,
+                dontDeleteSpecActionId: false,
                 addTime: false,
                 eventFilter: null
             })
@@ -460,6 +461,7 @@ describe('Ami Client internal functionality', function(){
                 emitEventsByTypes: false,
                 eventTypeToLowerCase: true,
                 emitResponsesById: false,
+                dontDeleteSpecActionId: true,
                 addTime: true,
                 eventFilter: new Set(['Dial'])
             };
@@ -559,6 +561,29 @@ describe('Ami Client internal functionality', function(){
                 .action({Action: 'Ping'});
             });
         });
+
+        it('Response have deleted generated ActionID field', done => {
+            client.connect(USERNAME, SECRET, {port: socketOptions.port}).then(() => {
+                client
+                    .on('response', response => {
+                        assert.ok(response.ActionID === undefined);
+                        done();
+                    })
+                    .action({Action: 'Ping'});
+            });
+        });
+
+        it('Response has generated ActionID field', done => {
+            client = new AmiClient({dontDeleteSpecActionId: true});
+            client.connect(USERNAME, SECRET, {port: socketOptions.port}).then(() => {
+                client.once('response', response => {
+                    assert.ok(/^--spec_\d{13}$/.test(response.ActionID));
+                    done();
+                })
+                .action({Action: 'Ping'});
+            });
+        });
+
 
     });
 


### PR DESCRIPTION
I'm calling multiple Originate actions in Async mode and I need to track them for replies. I don't want to generate own ActionIDs and I want to leave it to asterisk-ami-client.

For this purposes I added new option dontDeleteSpecActionId to AmiClient. Default behaviour is same as before, only after enable this option are returned Responses with generated ActionID. 