### PR TITLE
Avoid collision between successively generated ActionID

### DIFF
--- a/lib/AmiClient.js
+++ b/lib/AmiClient.js
@@ -297,13 +297,21 @@ class AmiClient extends EventEmitter{
 
     /**
      *
+     * @private
+     */
+    _random() {
+        return Math.floor(Math.random() * (10 ** 10));
+    }
+
+    /**
+     *
      * @param prefix
      * @returns {string}
      * @private
      */
     _genActionId(prefix){
         prefix = prefix || '';
-        return `${prefix}${Date.now()}`;
+        return `${prefix}${Date.now()}-${this._random()}`;
     }
 
     /**

--- a/test/amiClientTest.js
+++ b/test/amiClientTest.js
@@ -577,7 +577,8 @@ describe('Ami Client internal functionality', function(){
             client = new AmiClient({dontDeleteSpecActionId: true});
             client.connect(USERNAME, SECRET, {port: socketOptions.port}).then(() => {
                 client.once('response', response => {
-                    assert.ok(/^--spec_\d{13}$/.test(response.ActionID));
+                    console.log("actionid = ", response.ActionID);
+                    assert.ok(/^--spec_\d{13}-\d{1,10}$/.test(response.ActionID));
                     done();
                 })
                 .action({Action: 'Ping'});


### PR DESCRIPTION
Two actions sent in the same millisecond currently contain the same generated ActionID, so that subsequent responses will not be properly matched my the library.
This pull request adds a random component to the ActionID.